### PR TITLE
fix: prevent layout shift for card loading skeleton

### DIFF
--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -496,7 +496,7 @@ export function DataTable<TData, TValue>({
       {viewMode === 'cards' ? (
         <>
           {isLoading ? (
-            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
               {Array.from({ length: pageSize }).map((_, i) => (
                 <Card key={i}>
                   <CardContent className="space-y-3 p-4">


### PR DESCRIPTION
**Title**
fix: prevent layout shift for card loading skeleton

**Description**
This PR improves the loading experience of the card component by preventing layout shifts when the loading skeleton is rendered.

**Problem**
When the card enters the loading state, the skeleton component does not preserve the same spacing as the final content. This causes a noticeable layout shift when the content is loaded, which can affect the user experience.

A short video is attached below to demonstrate the issue and the improvement after applying the fix.

https://github.com/user-attachments/assets/a3cda733-8166-4d7f-8fa3-7cca800ce285



**Solution**
Add appropriate spacing to the skeleton layout so that it better matches the final rendered content. This helps maintain consistent layout dimensions during the loading state and prevents visual shifts.

**Demo**
See the attached video for a visual comparison of the behavior before and after the change.

https://github.com/user-attachments/assets/adfba589-e902-4c55-b0cc-4c7f11f6f70a

